### PR TITLE
Update app.component.ts

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -112,6 +112,7 @@ export class AppComponent {
   }
 
   testGoogle(){
+    this.awsService.getgoogleData(this);
     this.redError=null;
     this.success=null;
     let provider="google";


### PR DESCRIPTION
Hi, this the fix I did to force the googleCallback to be called in this component and set this.loggedInCreds before the call to testAccess. I don't think the duplicate calls to google (line 95 in here and line 50 in google-signin-component.ts) are required now but I am not sure why they fixed the issue even intermittently so I have left them alone.