### PR TITLE
force @1.0.0 to install for angular/cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ aws cognito-idp sign-up \
 10. Create a new "aws-cognito-apigw-angular" project folder by executing the following commands from a terminal in a host on which you want to run the application:
 
 ```
-npm install -g @angular/cli
+npm install -g @angular/cli@1.0.0
 ng new aws-cognito-apigw-angular
 cd aws-cognito-apigw-angular
 aws apigateway get-sdk --rest-api-id <RestApiId from CloudFormation OUTPUTS> --stage-name demo --sdk-type javascript apigwsdk.zip


### PR DESCRIPTION
potential resolution issue for #14 #15 

when you install the latest globally it will install >~6.0.8 where this project requires 1.0.0 per the package.json file.
...
},
  "devDependencies": {
    "@angular/cli": "1.0.0",
...