### PR TITLE
Update Lambda runtime to supported version

### DIFF
--- a/sam/sam.yaml
+++ b/sam/sam.yaml
@@ -410,7 +410,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs4.3
+      Runtime: nodejs8.10
       CodeUri: s3://<S3 BUCKET>/lambda.zip
       Policies: AmazonDynamoDBFullAccess
       Environment: 


### PR DESCRIPTION
Nodejs4.3 no longer supported by Lambda, seems to work (I have logs of the Lambda being successfully executed) with just the runtime changed.