### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/sam/sam.yaml
+++ b/sam/sam.yaml
@@ -410,7 +410,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       CodeUri: s3://<S3 BUCKET>/lambda.zip
       Policies: AmazonDynamoDBFullAccess
       Environment: 


### PR DESCRIPTION
CloudFormation templates in aws-cognito-apigw-angular-auth have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.