### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/sam/sam.yaml
+++ b/sam/sam.yaml
@@ -410,7 +410,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       CodeUri: s3://<S3 BUCKET>/lambda.zip
       Policies: AmazonDynamoDBFullAccess
       Environment: 


### PR DESCRIPTION
CloudFormation templates in aws-cognito-apigw-angular-auth have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.